### PR TITLE
fix bug arrow not being displayed on hackform

### DIFF
--- a/apps/dashboard/next.config.js
+++ b/apps/dashboard/next.config.js
@@ -8,7 +8,7 @@ const nextConfig = {
   nx: {
     // Set this to true if you would like to to use SVGR
     // See: https://github.com/gregberge/svgr
-    svgr: false,
+    svgr: true,
   },
   eslint: {
     ignoreDuringBuilds: true,

--- a/libs/ui-kit-2023/src/lib/arrow-button/arrow-button.tsx
+++ b/libs/ui-kit-2023/src/lib/arrow-button/arrow-button.tsx
@@ -1,7 +1,7 @@
 import { Colors2023 } from '@hacksc-platforms/styles';
 import styled from 'styled-components';
-import arrow from '../../assets/chevron-down.svg';
 import React from 'react';
+import Arrow from '../../assets/chevron-down.svg';
 
 /* eslint-disable-next-line */
 export interface ArrowButtonProps extends React.ButtonHTMLAttributes<any> {
@@ -12,7 +12,7 @@ export function ArrowButton(props: ArrowButtonProps) {
   return (
     <StyledArrowButton {...props} orientation={props.orientation}>
       <img
-        src={arrow}
+        src={Arrow}
         alt={`Arrow if pressed will go to the ${
           props.orientation === 'right' || props.orientation === 'down'
             ? 'next'


### PR DESCRIPTION
### Description

(_What have been done/changed_)

- I noticed this; here's the fix: you have to enable SVG support on `next.config.js` on your Next.js app if you want to use that arrow or anything from the kit that uses SVG. 

### Testing plan

(_How will we test the changes requested on this PR?_)

- [x] watch on Vercel previews
