### PR TITLE
Fix SSO signup

### DIFF
--- a/apps/sso/components/signup-card/signup-card.tsx
+++ b/apps/sso/components/signup-card/signup-card.tsx
@@ -39,15 +39,8 @@ export function SignUpCard(props: SignUpProps) {
         const message = error.message;
         setErrorMessage(message);
         setHideErrorMessage(false);
+        return;
       }
-    }
-
-    if (data.user.aud === 'authenticated') {
-      setErrorMessage(
-        'This email has already been registered. Please login instead.'
-      );
-      setHideErrorMessage(false);
-      return;
     }
 
     if (data.user) {


### PR DESCRIPTION
### Description

(_What have been done/changed_)

- Signup was broken, it was incorrectly checking for whether or not an email already exists but the supabase API does not have this functionality (see https://github.com/supabase/supabase-js/issues/296)
- We go back to not checking whether email already exists. I opened a separate issue for that [here](https://linear.app/hacksc-eng/issue/HIB-103/prevent-users-from-signing-up-with-existing-email) but I don't think it's solvable atm.

### Testing plan

(_How will we test the changes requested on this PR?_)

- [ ] ...
