### PR TITLE
Fix Dashboard port number

### DIFF
--- a/apps/dashboard/project.json
+++ b/apps/dashboard/project.json
@@ -25,7 +25,7 @@
       "options": {
         "buildTarget": "dashboard:build",
         "dev": true,
-        "port": 5000
+        "port": 4201
       },
       "configurations": {
         "development": {


### PR DESCRIPTION
Port 5000 is blocked on some Macs

Everyone will need to change their env variables after this is merged

### Description

(_What have been done/changed_)

- Change dashboard dev port to 4201

### Testing plan

(_How will we test the changes requested on this PR?_)

- [ ] ...
