### PR TITLE
better Python service generator + serverless template fix

### DIFF
--- a/tools/generators/hibiscus-python-library/schema.json
+++ b/tools/generators/hibiscus-python-library/schema.json
@@ -12,12 +12,12 @@
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "Library name:"
+      "x-prompt": "Library name (kebab-cased e.g 'test-lib'):"
     },
     "packageName": {
       "type": "string",
       "description": "Python package name",
-      "x-prompt": "Package name:"
+      "x-prompt": "Package name (snake-case of library name i.e if library name is 'test-lib' -> 'test_lib'):"
     },
     "moduleName": {
       "type": "string",

--- a/tools/generators/hibiscus-python-service/files/serverless.yml
+++ b/tools/generators/hibiscus-python-service/files/serverless.yml
@@ -20,7 +20,7 @@ provider:
 functions:
   api:
     handler: wsgi_handler.handler
-    environment: ${file(configs/env.${opt:stage,'local'}.yml)}
+    # environment: ${file(configs/env.${opt:stage,'local'}.yml)}
     events:
       - http: ANY /
       - http: ANY /{proxy+}

--- a/tools/generators/hibiscus-python-service/schema.json
+++ b/tools/generators/hibiscus-python-service/schema.json
@@ -12,12 +12,12 @@
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "Project name:"
+      "x-prompt": "Project name (kebab-cased e.g 'python-testing-service'):"
     },
     "packageName": {
       "type": "string",
       "description": "Python package name",
-      "x-prompt": "Python package name (e.g apps/<project_name>/<package_name>):"
+      "x-prompt": "Python package name (snake-case of project name i.e if project name is 'python-testing-service' -> 'python_testing_service'):"
     },
     "moduleName": {
       "type": "string",


### PR DESCRIPTION
### Description

(_What have been done/changed_)

- `functions.api.environment` should not be undefined -> can't take empty `env.*.yml` files; we uncomment it out by default i.e environment variables are not parsed by default
- clearer prompts for `hibiscus-python-service` and `hibiscus-python-library` generators

### Testing plan

(_How will we test the changes requested on this PR?_)

- [x] tested generating new Python service and immediately install and serve locally; works without errors
- [x] the generators' prompts showed up fine 
